### PR TITLE
docs(intro.md): add documentation for the build trigger command

### DIFF
--- a/docs/tooling/PandaPulse/intro.md
+++ b/docs/tooling/PandaPulse/intro.md
@@ -9,6 +9,19 @@ A monitoring tool for Ethereum networks that checks node health and reports issu
 ## Commands
 
 <details>
+<summary>Trigger build of client image</summary>
+
+- Run the `/build trigger {client} {optional:repository} {optional:ref} {optional:docker_tag}` command to trigger a build for a specific client.
+- If you do not provide a repository, it will default to the client's standard repository.
+- If you do not provide a ref, it will default to the client's standard branch.
+- You can specify a custom Docker tag if needed.
+
+**Note:**
+- Users with any client team role or admin role can trigger builds for any client.
+
+</details>
+
+<details>
 <summary>Register alerts for a new devnet</summary>
 
 - Setup a new discord channel, under the `bots` category in the `EthR&D` Guild.

--- a/docs/tooling/PandaPulse/intro.md
+++ b/docs/tooling/PandaPulse/intro.md
@@ -21,6 +21,8 @@ A monitoring tool for Ethereum networks that checks node health and reports issu
 
 </details>
 
+---
+
 <details>
 <summary>Register alerts for a new devnet</summary>
 


### PR DESCRIPTION
This commit adds documentation for the `/build trigger` command, explaining its usage, parameters, and user permissions. This enhances the documentation for PandaPulse, providing users with clear instructions on how to trigger builds for specific clients.